### PR TITLE
Improve automation

### DIFF
--- a/npm2deb/__init__.py
+++ b/npm2deb/__init__.py
@@ -156,10 +156,11 @@ and may not include tests.\n""")
 
     def test_uscan(self):
         info = _getstatusoutput('uscan --watchfile "debian/watch" '
-                                    '--package "{}" '
-                                    '--upstream-version 0 '
-                                    '--download-version {} '
-                                    .format(self.debian_name, self.upstream_version))
+                                '--package "{}" '
+                                '--upstream-version 0 '
+                                '--download-version {} '
+                                '--no-download'
+                                .format(self.debian_name, self.upstream_version))
         return info
 
 

--- a/npm2deb/__init__.py
+++ b/npm2deb/__init__.py
@@ -144,6 +144,8 @@ You may want fix first these issues:\n""")
         print ("\nBuilding the binary package")
         _call('dpkg-source -b .', shell=True)
         _call('dpkg-buildpackage', shell=True)
+        # removing auto generated temporary files
+        _call('fakeroot debian/rules clean', shell=True)
 
     def run_uupdate(self, tar_file):
         print ('\nCreating debian source package...')

--- a/npm2deb/__init__.py
+++ b/npm2deb/__init__.py
@@ -37,6 +37,7 @@ class Npm2Deb(object):
         self.debian_standards = STANDARDS_VERSION
         self.debian_debhelper = DEBHELPER
         self.noclean = False
+        self.uscan_info = ''
         if args:
             if 'upstream_license' in args and args['upstream_license']:
                 self.upstream_license = args['upstream_license']
@@ -91,11 +92,10 @@ class Npm2Deb(object):
         Try building deb package after creating required files using start().
         'uscan', 'uupdate' and 'dpkg-buildpackage' are run if debian/watch is OK.
         """
-        uscan_info = self.test_uscan()
-        if uscan_info[0] == 0:
+        if self.uscan_info[0] == 0:
             self.run_uscan()
             
-            remote_file_name = uscan_info[1].split(' ')[-1].split('/')[-1].replace('v','')
+            remote_file_name = self.uscan_info[1].split(' ')[-1].split('/')[-1].replace('v','')
             tar_file_name = '%s-%s' % (self.debian_name, remote_file_name)
             self.run_uupdate(tar_file_name)
             
@@ -119,7 +119,7 @@ You may want fix first these issues:\n""")
         utils.change_dir(saved_path)
         _call('/bin/grep --color=auto FIX_ME -r %s/*' % debian_path, shell=True)
 
-        if uscan_info[0] != 0:
+        if self.uscan_info[0] != 0:
             print ("\nUse uscan to get orig source files. Fix debian/watch and then run\
                     \n$ uscan --download-current-version\n")
 
@@ -158,7 +158,7 @@ You may want fix first these issues:\n""")
                                     '--package "{}" '
                                     '--upstream-version 0 --no-download'
                                     .format(self.debian_name))
-        return info
+        self.uscan_info = info
 
         
     def create_itp_bug(self):
@@ -194,9 +194,9 @@ You may want fix first these issues:\n""")
 
             utils.create_debian_file('watch', content)
             # test watch with uscan, raise exception if status is not 0
-            uscan_info = self.test_uscan()
+            self.test_uscan()
             
-            if uscan_info[0] != 0:
+            if self.uscan_info[0] != 0:
                 raise ValueError
 
         except ValueError:

--- a/npm2deb/__init__.py
+++ b/npm2deb/__init__.py
@@ -118,11 +118,9 @@ class Npm2Deb(object):
 
             utils.create_debian_file('watch', content)
             # test watch with uscan, raise exception if status is not 0
-            info = _getstatusoutput('uscan --watchfile "debian/watch" '
-                                    '--package "{}" '
-                                    '--upstream-version 0 --no-download'
-                                    .format(self.debian_name))
-            if info[0] != 0:
+            uscan_info = self.test_uscan()
+            
+            if uscan_info[0] != 0:
                 raise ValueError
 
         except ValueError:
@@ -343,6 +341,17 @@ class Npm2Deb(object):
         self._get_json_description()
         self._get_json_version()
         self._get_json_license()
+
+    def test_uscan(self):
+        info = _getstatusoutput('uscan --watchfile "debian/watch" '
+                                    '--package "{}" '
+                                    '--upstream-version 0 --no-download'
+                                    .format(self.debian_name))
+        return info
+
+    def run_uscan(self):
+        print ('\nDownloading source tarball file using debian/watch file...')
+        _os.system('uscan --download-current-version')    
 
     def download(self):
         utils.debug(1, "downloading %s via npm" % self.name)

--- a/npm2deb/__init__.py
+++ b/npm2deb/__init__.py
@@ -95,13 +95,7 @@ class Npm2Deb(object):
         uscan_info = self.test_uscan()
         if uscan_info[0] == 0:
             self.run_uscan()
-
-            for name in _os.listdir('..'):
-                orig_file = _re.search('%s_(\d.*)\.orig\..*' % self.debian_name, name)
-                if orig_file:
-                    orig_file = orig_file.group(0)
-                    break
-            self.run_uupdate(orig_file)
+            self.run_uupdate()
 
             new_dir = '%s-%s' % (self.debian_name, self.upstream_version)
             utils.change_dir('../%s' % new_dir)
@@ -146,9 +140,9 @@ and may not include tests.\n""")
         # removing auto generated temporary files
         _call('debian/rules clean', shell=True)
 
-    def run_uupdate(self, tar_file):
+    def run_uupdate(self):
         print ('\nCreating debian source package...')
-        _call('uupdate -b ../%s' % tar_file, shell=True)
+        _call('uupdate -b -f --upstream-version %s' % self.upstream_version, shell=True)
 
     def run_uscan(self):
         print ('\nDownloading source tarball file using debian/watch file...')

--- a/npm2deb/__init__.py
+++ b/npm2deb/__init__.py
@@ -104,6 +104,8 @@ class Npm2Deb(object):
             utils.change_dir('../%s' % new_dir_name)
             self.run_buildpackage()
 
+            self.edit_changelog()
+            
             debian_path = "%s/%s/debian" % (self.name, new_dir_name)
             print ('\nRemember, your new source directory is %s/%s' % (self.name, new_dir_name))
             
@@ -121,7 +123,23 @@ You may want fix first these issues:\n""")
             print ("\nUse uscan to get orig source files. Fix debian/watch and then run\
                     \n$ uscan --download-current-version\n")
 
-    
+
+    def edit_changelog(self):
+        """
+        This function is to remove extra line '* New upstream release' 
+        from debian/changelog 
+        """
+        with open('debian/changelog', 'r') as f:
+            data = f.read()
+        f.close()
+        
+        data_list = data.split('\n')
+        data_list.pop(3)
+
+        with open('debian/changelog', 'w') as f:
+            f.write('\n'.join(data_list))
+        f.close()
+        
     def run_buildpackage(self):
         print ("\nBuilding the binary package")
         _call('dpkg-source -b .', shell=True)

--- a/npm2deb/scripts.py
+++ b/npm2deb/scripts.py
@@ -289,7 +289,7 @@ def create(args):
             compression_format = _re.search('\.(?:zip|tgz|tbz|txz|(?:tar\.(?:gz|bz2|xz)))', tar_file).group(0)                                         
             new_dir_name = tar_file.replace(compression_format, '')
             debian_path = "%s/%s/debian" % (npm2deb.name, new_dir_name)
-            print ('\nRemember, your new source directory is ', debian_path, '\n')
+            print ('\nRemember, your new source directory is %s/%s' % (npm2deb.name, new_dir_name))
         else:
             debian_path = "%s/%s/debian" % (npm2deb.name, npm2deb.debian_name)
         

--- a/npm2deb/scripts.py
+++ b/npm2deb/scripts.py
@@ -2,7 +2,6 @@ from argparse import ArgumentParser as _ArgumentParser
 from subprocess import call as _call
 import os as _os
 import sys as _sys
-import re as _re
 
 from npm2deb import Npm2Deb as _Npm2Deb
 from npm2deb import utils as _utils
@@ -276,38 +275,7 @@ def create(args):
         _utils.change_dir(npm2deb.name)
         npm2deb.start()
         _utils.change_dir(npm2deb.debian_name)
-
-        # run uscan if debian/watch is ok
-        uscan_info = npm2deb.test_uscan()
-
-        if uscan_info[0] == 0:
-            npm2deb.run_uscan()
-            remote_file_name = uscan_info[1].split(' ')[-1].split('/')[-1].replace('v','')
-            tar_file = '%s-%s' % (npm2deb.debian_name, remote_file_name)
-            print ('\nCreating debian source package...')
-            _call('uupdate -b ../%s' % tar_file, shell=True)
-            compression_format = _re.search('\.(?:zip|tgz|tbz|txz|(?:tar\.(?:gz|bz2|xz)))', tar_file).group(0)                                         
-            new_dir_name = tar_file.replace(compression_format, '')
-            _utils.change_dir('../%s' % new_dir_name)
-            print ("\nBuilding the binary package")
-            _call('dpkg-source -b .', shell=True)
-            _call('dpkg-buildpackage', shell=True)
-
-            debian_path = "%s/%s/debian" % (npm2deb.name, new_dir_name)
-            print ('\nRemember, your new source directory is %s/%s' % (npm2deb.name, new_dir_name))
-        else:
-            debian_path = "%s/%s/debian" % (npm2deb.name, npm2deb.debian_name)
-        
-        print("""
-This is not a crystal ball, so please take a look at auto-generated files.\n
-You may want fix first these issues:\n""")
-        
-        _utils.change_dir(saved_path)
-        _call('/bin/grep --color=auto FIX_ME -r %s/*' % debian_path, shell=True)
-
-        if uscan_info[0] != 0:
-            print ("\nUse uscan to get orig source files. Fix debian/watch and then run\
-                    \n$ uscan --download-current-version\n")    
+        npm2deb.initiate_build(saved_path)
  
     except OSError as os_error:
         print(str(os_error))

--- a/npm2deb/scripts.py
+++ b/npm2deb/scripts.py
@@ -288,6 +288,11 @@ def create(args):
             _call('uupdate -b ../%s' % tar_file, shell=True)
             compression_format = _re.search('\.(?:zip|tgz|tbz|txz|(?:tar\.(?:gz|bz2|xz)))', tar_file).group(0)                                         
             new_dir_name = tar_file.replace(compression_format, '')
+            _utils.change_dir('../%s' % new_dir_name)
+            print ("\nBuilding the binary package")
+            _call('dpkg-source -b .', shell=True)
+            _call('dpkg-buildpackage', shell=True)
+
             debian_path = "%s/%s/debian" % (npm2deb.name, new_dir_name)
             print ('\nRemember, your new source directory is %s/%s' % (npm2deb.name, new_dir_name))
         else:

--- a/npm2deb/scripts.py
+++ b/npm2deb/scripts.py
@@ -276,7 +276,7 @@ def create(args):
         npm2deb.start()
         _utils.change_dir(npm2deb.debian_name)
         npm2deb.initiate_build(saved_path)
- 
+
     except OSError as os_error:
         print(str(os_error))
         exit(1)


### PR DESCRIPTION
Fixes [https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=840174](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=840174)
This should add more power to npm2deb package. It seem manual steps done for building packages can be automated if debian/watch file is correct.
This update will check debian/watch file generated and run 'uscan', 'uupdate' & 'dpkg-buildpackage' commands, which makes debian packaging more easier.