### PR TITLE
Fix for npm v1.4

### DIFF
--- a/npm2deb/__init__.py
+++ b/npm2deb/__init__.py
@@ -169,7 +169,12 @@ class Npm2Deb(object):
 
         # install files from files field
         if 'files' in self.json:
-            libs = libs.union(self.json['files'])
+            files = self.json['files']
+            # npm v1.4 returns string if files field has only one entry
+            if isinstance(files, str):
+                libs.add(files)
+            else:
+                libs = libs.union(files)
 
         # install main if not in a subpath
         if 'main' in self.json:


### PR DESCRIPTION
npm v1.4 (sid version) returns string if files field has a single entry.

This patch could be removed when npm gets upgraded to v3.10 as it always returns array