### PR TITLE
Fallback homepage to npmjs.com module page

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[**]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+# 4 space indentation
+[*.py]
+indent_style = space
+indent_size = 4

--- a/npm2deb/__init__.py
+++ b/npm2deb/__init__.py
@@ -535,13 +535,14 @@ and may not include tests.\n""")
     def _get_json_homepage(self):
         if self.homepage:
             return
-        result = 'FIX_ME homepage'
+
         if 'homepage' in self.json:
-            result = self.json['homepage']
+            self.homepage = self.json['homepage']
         elif self.upstream_repo_url and not \
-                self.upstream_repo_url.find('FIX_ME') >= 0:
-            result = self.upstream_repo_url
-        self.homepage = result
+             self.upstream_repo_url.find('FIX_ME') >= 0:
+            self.homepage = self.upstream_repo_url
+        else:
+            self.homepage = utils.get_npmjs_homepage(self.name)
 
     def _get_Depends(self):
         depends = ['nodejs']

--- a/npm2deb/utils.py
+++ b/npm2deb/utils.py
@@ -110,3 +110,6 @@ def create_dir(dir):
 
 def debianize_name(name):
     return name.replace('_', '-').lower()
+
+def get_npmjs_homepage(name):
+    return 'https://npmjs.com/package/' + name


### PR DESCRIPTION
use npmjs.com module page as homepage url if homepage and upstream repo url are not set

Fixes #41 