### PR TITLE
Refactor package search

### DIFF
--- a/npm2deb/helper.py
+++ b/npm2deb/helper.py
@@ -78,32 +78,6 @@ def search_for_bug(module):
                     continue
         return result
 
-def search_in_new(module):
-    if isinstance(module, _Npm2Deb):
-        module = module.name
-    my_print('Looking for packages in NEW:')
-    _debug(1, "calling new-check")
-    found = False
-    formatted = "  {0:20} {1:>3}"
-    url = "https://api.ftp-master.debian.org/sources_in_suite/new"
-    _debug(1, "opening url %s" % url)
-    data = _urlopen(url).read().decode('utf-8')
-    data = _parseJSON(data)
-    result = []
-    for package in data:
-        name = package['source']
-        version = package['version']
-        if not module in name:
-            continue
-        found = True
-        result.append(package)
-        my_print(formatted.format(package['source'],
-                                  package['version']
-                                 ))
-    if not found:
-        my_print("  None")
-    return result
-
 def search_for_reverse_dependencies(module):
     if isinstance(module, _Npm2Deb):
         module = module.name

--- a/npm2deb/helper.py
+++ b/npm2deb/helper.py
@@ -26,10 +26,6 @@ def search_for_repository(module):
     found = False
     result = {}
     my_print("Looking for existing repositories:")
-    content = _getstatusoutput(["rmadison -u debian node-"+module])
-    if content[1]:
-    	print(content[1]),
-    	found = True
     for repo in repositories:
         _debug(1, "search for %s in %s" % (module, repo))
         url_base = "http://anonscm.debian.org/gitweb"

--- a/npm2deb/mapper.py
+++ b/npm2deb/mapper.py
@@ -35,6 +35,7 @@ class Mapper(object):
         result['info'] = None
         result['name'] = None
         result['version'] = None
+        result['suite'] = None
         result['repr'] = None
 
         if node_module in self.json:
@@ -58,7 +59,7 @@ class Mapper(object):
             return result
 
         madison = _getstatusoutput(
-            'rmadison -s sid "%s" | grep source' % result['name'])
+            'rmadison -u debian "%s" | grep source' % result['name'])
 
         if madison[0] != 0:
             result['name'] = None
@@ -68,6 +69,7 @@ class Mapper(object):
         if len(tmp) >= 2:
             result['name'] = tmp[0].strip()
             result['version'] = tmp[1].strip()
+            result['suite'] = tmp[2].strip()
             result['repr'] = '%s (%s)' % (result['name'], result['version'])
 
         return result

--- a/npm2deb/scripts.py
+++ b/npm2deb/scripts.py
@@ -100,9 +100,6 @@ def main(argv=None):
         '-d', '--debian', action="store_true",
         default=False, help='search for existing package in debian')
     parser_search.add_argument(
-        '-n', '--new', action="store_true",
-        default=False, help='search for existing package in NEW queue')
-    parser_search.add_argument(
         '-r', '--repository', action="store_true",
         default=False, help='search for existing repository in alioth')
     parser_search.add_argument(
@@ -142,11 +139,10 @@ def main(argv=None):
 def search_for_module(args):
     _helper.DO_PRINT = True
     # enable all by default
-    if not args.bug and not args.debian and not args.repository and not args.new:
+    if not args.bug and not args.debian and not args.repository:
         args.bug = True
         args.debian = True
         args.repository = True
-        args.new = True
     node_module = get_npm2deb_instance(args).name
     if args.debian:
         print("\nLooking for similiar package:")
@@ -158,9 +154,6 @@ def search_for_module(args):
     if args.bug:
         print("")
         _helper.search_for_bug(node_module)
-    if args.new:
-        print("")
-        _helper.search_in_new(node_module)
     print("")
 
     _show_mapper_warnings()

--- a/npm2deb/scripts.py
+++ b/npm2deb/scripts.py
@@ -139,7 +139,7 @@ def main(argv=None):
 def search_for_module(args):
     _helper.DO_PRINT = True
     # enable all by default
-    if not args.bug and not args.debian and not args.repository:
+    if not (args.bug or args.debian or args.repository):
         args.bug = True
         args.debian = True
         args.repository = True
@@ -147,7 +147,8 @@ def search_for_module(args):
     if args.debian:
         print("\nLooking for similiar package:")
         mapper = _Mapper.get_instance()
-        print("  %s" % mapper.get_debian_package(node_module)['repr'])
+        pkg_info = mapper.get_debian_package(node_module)
+        print("  %s (%s)" % (pkg_info['repr'], pkg_info['suite']))
     if args.repository:
         print("")
         _helper.search_for_repository(node_module)
@@ -182,8 +183,9 @@ def print_view(args):
                   getattr(npm2deb_instance, attr_key, None)))
 
         mapper = _Mapper.get_instance()
-        print(formatted.format("Debian:", mapper
-              .get_debian_package(npm2deb_instance.name)['repr']))
+        pkg_info = mapper.get_debian_package(npm2deb_instance.name)
+        print(formatted.format("Debian:",
+                               "%s (%s)" % (pkg_info['repr'], pkg_info['suite'])))
 
         if mapper.has_warnings():
             print("")


### PR DESCRIPTION
Uses `rmadison -u debian` for package search which combines results from all suites.
It also avoids need for separate search in NEW queue.

Now `npm2deb view <module>` shows a Debian entry if the module is in NEW/experimental too.