### PR TITLE
Exclude unwanted files from debian/install

### DIFF
--- a/npm2deb/__init__.py
+++ b/npm2deb/__init__.py
@@ -236,7 +236,8 @@ and may not include tests.\n""")
         libs.remove('debian')
 
         for filename in libs:
-            content += "%s %s/\n" % (filename, self.debian_dest)
+            if not utils.is_ignored(filename):
+                content += "%s %s/\n" % (filename, self.debian_dest)
         utils.create_debian_file('install', content)
 
     def create_docs(self):

--- a/npm2deb/utils.py
+++ b/npm2deb/utils.py
@@ -9,6 +9,16 @@ from npm2deb import templates as _templates
 
 
 DEBUG_LEVEL = 0
+# files starting with this strings will not be included in debian/install
+IGNORED_FILES = [
+    '.',                                  # dotfiles
+    'readme',                             # readme
+    'history', 'changelog',               # history files
+    'license', 'copyright', 'licence',    # legal files
+    'gruntfile', 'gulpfile', 'makefile',  # buid system files
+    'karma.conf', 'bower.json',
+    'test'                                # test files
+]
 
 def debug(level, msg):
     if level <= DEBUG_LEVEL:
@@ -19,6 +29,13 @@ def get_npm_version(module_name):
     return _getstatusoutput(
         'npm view "%s" version' % module_name)[1].split('\n')[-2].strip()
 
+def is_ignored(filename):
+    filename = filename.lower()
+    for pattern in IGNORED_FILES:
+        if filename.startswith(pattern):
+            return True
+
+    return False
 
 def get_template(filename):
     result = None


### PR DESCRIPTION
npm includes a lot of files like licence, changelog, etc... that are
not supposed to be shipped in /usr/lib/<package>/ or at all.

Fixes #74 