### PR TITLE
Updated __init__.py - Updated standards and debhelper version.

### DIFF
--- a/npm2deb/__init__.py
+++ b/npm2deb/__init__.py
@@ -13,8 +13,8 @@ from npm2deb import utils, templates
 from npm2deb.mapper import Mapper
 
 VERSION = '0.2.6'
-DEBHELPER = 9
-STANDARDS_VERSION = '3.9.8'
+DEBHELPER = 10
+STANDARDS_VERSION = '4.1.1'
 
 
 class Npm2Deb(object):


### PR DESCRIPTION
The standards and debhelper version were outdated, updating them as per the lates version of debian policy