### PR TITLE
Make npm2deb create work with npm 6 

### DIFF
--- a/npm2deb/__init__.py
+++ b/npm2deb/__init__.py
@@ -409,8 +409,7 @@ and may not include tests.\n""")
             exception = "Error downloading package %s\n" % self.name
             exception += info[1]
             raise ValueError(exception)
-
-        tarball_file = info[1].strip('\n')
+        tarball_file = info[1].split('\n')[-1]
         tarball = tarfile.open(tarball_file)
         # get the root directory name
         root_dir = tarball.getnames()[0]


### PR DESCRIPTION
In npm version > 6, npm pack command returns multiple lines of data,
in which the last line is the package name. Using that should fix
the error while using npm2deb with all the current & previous versions
of npm

Fixes #112 