### PR TITLE
Remove dh-buildinfo from build deps

### DIFF
--- a/npm2deb/templates.py
+++ b/npm2deb/templates.py
@@ -26,7 +26,6 @@ Maintainer: Debian Javascript Maintainers <pkg-javascript-devel@lists.alioth.deb
 Uploaders: %(Uploaders)s
 Build-Depends:
  debhelper (>= %(debhelper)s)
- , dh-buildinfo
  , nodejs (>= 6)
 Standards-Version: %(Standards-Version)s
 Homepage: %(Homepage)s


### PR DESCRIPTION
Not required from debhelper compat 10