### PR TITLE
github tags page is no longer working with uscan

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 ## 0.2.8 (2018-08-15)
  * [fix] Exclude unwanted files from debian/install
+ * [fix] Switch to releases page in watch instead of now broken tags page
  * [new] Move primary search from alioth to salsa - closes #106
  * [new] Support scopes, ie, '@<scope>/' in module names
  * [new] Use latest standards version

--- a/npm2deb/templates.py
+++ b/npm2deb/templates.py
@@ -328,7 +328,7 @@ WATCH['github'] = """version=3
 opts=\\
 dversionmangle=%(dversionmangle)s,\\
 filenamemangle=s/.*\/v?([\d\.-]+)\.tar\.gz/%(debian_name)s-$1.tar.gz/ \\
- %(url)s/tags .*/archive/v?([\d\.]+).tar.gz
+ %(url)s/releases .*/archive/v?([\d\.]+).tar.gz
 """
 
 WATCH['fakeupstream'] = """version=3


### PR DESCRIPTION
Use releases page instead, which still works.