### PR TITLE
Replace fakeupstream by npmregistry

### DIFF
--- a/npm2deb/__init__.py
+++ b/npm2deb/__init__.py
@@ -128,7 +128,7 @@ You may want fix first these issues:\n""")
 
         if self.upstream_watch:
             print("""
-*** Warning ***\nUsing fakeupstream to download npm dist tarballs, because upstream
+*** Warning ***\nUsing npmregistry to download npm dist tarballs, because upstream
 git repo is missing tags. Its better to ask upstream to tag their releases
 instead of using npm dist tarballs as dist tarballs may contain pre built files
 and may not include tests.\n""")
@@ -200,7 +200,7 @@ and may not include tests.\n""")
             if self.upstream_repo_url.find('github') >= 0:
                 content = utils.get_watch('github') % args
             else:
-                # if not supported, got to fakeupstream
+                # if not supported, got to npmregistry
                 raise ValueError
 
             utils.create_debian_file('watch', content)
@@ -212,7 +212,7 @@ and may not include tests.\n""")
 
         except ValueError:
             self.upstream_watch = True
-            content = utils.get_watch('fakeupstream') % args
+            content = utils.get_watch('npmregistry') % args
             content = _re.sub('\.\*=@.*/', '.*=', content)
             utils.create_debian_file('watch', content)
 

--- a/npm2deb/templates.py
+++ b/npm2deb/templates.py
@@ -327,15 +327,12 @@ filenamemangle=s/.*\/v?([\d\.-]+)\.tar\.gz/%(debian_name)s-$1.tar.gz/ \\
  %(url)s/releases .*/archive/v?([\d\.]+).tar.gz
 """
 
-WATCH['fakeupstream'] = """version=4
-# It is not recommended use fakeupstream. Please investigate more.
+WATCH['npmregistry'] = """version=4
+# It is not recommended use npmregistry. Please investigate more.
 # Origin url: %(url)s
 # Take a look at https://wiki.debian.org/debian/watch/
-# See also fakeupstream: http://anonscm.debian.org/viewvc/qa/trunk/cgi-bin/fakeupstream.cgi?view=markup
-opts=\\
-dversionmangle=%(dversionmangle)s,\\
-filenamemangle=s/.*=// \\
- https://qa.debian.org/cgi-bin/fakeupstream.cgi?upstream=npmjs/%(module)s .*=%(module)s-(\d.*)\.(?:tgz|tar\.(?:gz|bz2|xz))
+opts="searchmode=plain,pgpmode=none" \
+ https://registry.npmjs.org/%(module)s https://registry.npmjs.org/%(module)s/-/%(module)s-(\d[\d\.]*)@ARCHIVE_EXT@
 """
 
 METADATA = {}

--- a/npm2deb/utils.py
+++ b/npm2deb/utils.py
@@ -65,7 +65,7 @@ def get_watch(which):
     elif which == 'bitbucket':
         return _templates.WATCH['bitbucket']
     else:
-        return _templates.WATCH['fakeupstream']
+        return _templates.WATCH['npmregistry']
 
 
 def get_upstream_metadata(which):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -136,20 +136,20 @@ class debian(unittest.TestCase):
         line = self._get_debfile_line('watch', '/tags')
         self.assertTrue(line is not None and len(line) > 0)
 
-    def test_watch_fakeupstream(self):
-        # must create a fakeupstream since we do not know about git url
+    def test_watch_npmregistry(self):
+        # must create a npmregistry since we do not know about git url
         n = Npm2Deb('yg-panache')
         n.create_base_debian()
         n.create_watch()
-        line = self._get_debfile_line('watch', '/fakeupstream')
+        line = self._get_debfile_line('watch', '/npmregistry')
         self.assertTrue(line is not None and len(line) > 0)
 
     def test_watch_github_with_no_tags(self):
-        # must fallback on fakeupstream if no tags in github
+        # must fallback on npmregistry if no tags in github
         n = Npm2Deb('security')
         n.create_base_debian()
         n.create_watch()
-        line = self._get_debfile_line('watch', '/fakeupstream')
+        line = self._get_debfile_line('watch', '/npmregistry')
         self.assertTrue(line is not None and len(line) > 0)
 
     def test_repository_defined_as_string(self):


### PR DESCRIPTION
Needs devscripts >= 2.18.5

Uses new uscan feature that allows one to query npmjs registry