### PR TITLE
Fix BSD case

### DIFF
--- a/npm2deb/templates.py
+++ b/npm2deb/templates.py
@@ -166,7 +166,7 @@ LICENSES['Artistic'] = """Artistic-1.0
  can be found in "/usr/share/common-licenses/Artistic".
 """
 
-LICENSES['BSD-2-clause'] = """BSD-2-clause
+LICENSES['BSD-2-clause'] = """%(name)s
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
  are met:
@@ -189,7 +189,7 @@ LICENSES['BSD-2-clause'] = """BSD-2-clause
  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-LICENSES['BSD-3-clause'] = """BSD-3-clause
+LICENSES['BSD-3-clause'] = """%(name)s
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
  are met:
@@ -215,7 +215,7 @@ LICENSES['BSD-3-clause'] = """BSD-3-clause
  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-LICENSES['BSD-4-clause'] = """BSD-4-clause
+LICENSES['BSD-4-clause'] = """%(name)s
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
  are met:

--- a/npm2deb/utils.py
+++ b/npm2deb/utils.py
@@ -79,6 +79,8 @@ def get_gbp_conf():
 def get_license(license):
     result = None
     name = license.lower().replace('-', '')
+    args = {}
+    args['name'] = license
     if name.startswith('gpl2'):
         result = _templates.LICENSES['GPL-2']
     elif name.startswith('gpl3'):
@@ -92,11 +94,11 @@ def get_license(license):
     elif name.startswith('expat'):
         result = _templates.LICENSES['Expat']
     elif name.startswith('bsd4'):
-        result = _templates.LICENSES['BSD-4-clause']
+        result = _templates.LICENSES['BSD-4-clause'] % args
     elif name.startswith('bsd2'):
-        result = _templates.LICENSES['BSD-2-clause']
+        result = _templates.LICENSES['BSD-2-clause'] % args
     elif name.startswith('bsd'):
-        result = _templates.LICENSES['BSD-3-clause']
+        result = _templates.LICENSES['BSD-3-clause'] % args
     elif name.startswith('artistic'):
         result = _templates.LICENSES['Artistic']
     elif name.startswith('apache'):


### PR DESCRIPTION
When upstream uses 'BSD-2-Clause', debian/copyright is wrong:
```
Files: *
Copyright: 2019, ...
License: BSD-2-Clause

License: BSD-2-clause
```
This fix uses the same license as given by upstream. Another way could be to just fix license name in `templates.py`