### PR TITLE
Create debian/tests/pkg-js

### DIFF
--- a/npm2deb/__init__.py
+++ b/npm2deb/__init__.py
@@ -352,7 +352,7 @@ and may not include tests.\n""")
         _os.system('chmod +x debian/rules')
 
     def create_tests(self):
-        utils.create_dir("debian/tests")
+        utils.create_dir("debian/tests/pkg-js")
         args = {}
         args['name'] = self.name
         args['debian_name'] = self.debian_name


### PR DESCRIPTION
For now, npm2deb creates a `debian/tests`. Since we switched to pkg-js-tools this dir is empty, so we have to choose between:
 * create `debian/tests/pkg-js`
 * don't create `debian/tests`