### PR TITLE
Debianize dependency names in debian/control

### DIFF
--- a/npm2deb/__init__.py
+++ b/npm2deb/__init__.py
@@ -552,7 +552,7 @@ and may not include tests.\n""")
             for dep in dependencies:
                 name = mapper.get_debian_package(dep)['name']
                 if not name:
-                    name = 'node-%s' % dep
+                    name = 'node-%s' % utils.debianize_name(dep)
                     mapper.append_warning(
                         'error', dep, 'dependency %s '
                         'not in debian' % (name))


### PR DESCRIPTION
One more fix regarding issue #120, and the @ character in node package names.