### PR TITLE
Update github watch template

### DIFF
--- a/npm2deb/templates.py
+++ b/npm2deb/templates.py
@@ -321,8 +321,8 @@ WATCH = {}
 WATCH['github'] = """version=4
 opts=\\
 dversionmangle=%(dversionmangle)s,\\
-filenamemangle=s/.*\/v?([\d\.-]+)\.tar\.gz/%(debian_name)s-$1.tar.gz/ \\
- %(url)s/releases .*/archive/v?([\d\.]+).tar.gz
+filenamemangle=s/.+\/v?(\d\S+)\.tar\.gz/%(modulename)s-$1\.tar\.gz/ \\
+ %(url)s/tags .*/v?(\d\S+)\.tar\.gz
 """
 
 WATCH['gitlab'] = """version=4


### PR DESCRIPTION
Hello upstream maintainer, this commit changes the watch file template for github packages to the recommended template https://wiki.debian.org/debian/watch#GitHub