### PR TITLE
Change debian_name if git repository is created successfully

### DIFF
--- a/npm2deb/__init__.py
+++ b/npm2deb/__init__.py
@@ -107,6 +107,9 @@ class Npm2Deb(object):
             self.edit_changelog()
             self.create_git_repository()
 
+            if not _os.path.exists(_os.path.join(saved_path, self.name, new_dir)):
+                new_dir = self.debian_name
+
             debian_path = "%s/%s/debian" % (self.name, new_dir)
             print('\nRemember, your new source directory is %s/%s' %
                   (self.name, new_dir))


### PR DESCRIPTION
One (cosmetic) bug that #149 introduced is that the debian_path remains stuck to the `node-{module}-{version}` even if creating a git repo is successful and the `node-{module}-{version}` is pruned (which is un-needed anyway after `.dsc` has been imported).

This gave weird logs like: "/bin/grep: uniq/node-uniq-1.0.1/debian/*: No such file or directory" as can be seen [here](https://github.com/LeoIannacone/npm2deb/pull/149#issuecomment-687187055)

This is an attempt to fix the same. Please consider merging.

==================================================================================================

cc: @shanavas786